### PR TITLE
do not store secret key information in reason

### DIFF
--- a/lib/resty/jwt.lua
+++ b/lib/resty/jwt.lua
@@ -199,7 +199,7 @@ local function derive_keys(enc, secret_key)
   end
 
   if #secret_key ~= secret_key_len then
-    error({reason="The pre-shared content key must be ".. secret_key_len})
+    error({reason="invalid pre-shared key"})
   end
 
   local mac_key = string_sub(secret_key, 1, mac_key_len)
@@ -779,7 +779,7 @@ function _M.verify_jwt_obj(self, secret, jwt_obj, ...)
         cert, err = evp.PublicKey:new(secret)
       end
       if not cert then
-        jwt_obj[str_const.reason] = "Decode secret is not a valid cert/public key: " .. (err and err or secret)
+        jwt_obj[str_const.reason] = "Decode secret is not a valid cert/public key"
         return jwt_obj
       end
     else

--- a/t/load-verify.t
+++ b/t/load-verify.t
@@ -604,7 +604,7 @@ R0FSQkFHRQo=
 GET /t
 --- response_body
 false
-Decode secret is not a valid cert/public key: ASN1 lib: nested asn1 error: bad object header: too long
+Decode secret is not a valid cert/public key
 test
 --- no_error_log
 [error]


### PR DESCRIPTION
This prevents the actual shared secret from leaking to clients or log
messages.