### PR TITLE
fix OpenSSL 1.1 support

### DIFF
--- a/lib/resty/evp.lua
+++ b/lib/resty/evp.lua
@@ -134,12 +134,13 @@ end
 
 local ctx_new, ctx_free
 local openssl11, e = pcall(function ()
-    local ctx = _C.HMAC_CTX_new()
-    _C.HMAC_CTX_free(ctx)
+    local ctx = _C.EVP_MD_CTX_new()
+    _C.EVP_MD_CTX_free(ctx)
 end)
+
 if openssl11 then
     ctx_new = function ()
-        return _C.HMAC_CTX_new()
+        return _C.EVP_MD_CTX_new()
     end
     ctx_free = function (ctx)
         ffi.gc(ctx, _C.EVP_MD_CTX_free)
@@ -153,7 +154,6 @@ else
         ffi.gc(ctx, _C.EVP_MD_CTX_destroy)
     end
 end
-
 
 local RSASigner = {}
 _M.RSASigner = RSASigner


### PR DESCRIPTION
Fixed allocating HMAC objects instead of EVP MD CTX.

> bad argument #1 to 'EVP_DigestInit_ex' (cannot convert 'struct hmac_ctx_st *' to 'struct env_md_ctx_st *')

@cybrq-as this looks like a copy-paste error from the hmac.lua.