### PR TITLE
Update test suite and fix OpenSSL 1.1 support

### DIFF
--- a/ci
+++ b/ci
@@ -14,7 +14,7 @@ case "${1:?}" in
                -v "$(pwd)":/lua-resty-jwt \
                -w /lua-resty-jwt \
                --name lua-resty-jwt-tests \
-               skylothar/openresty-testsuite:latest \
+               cdbattags/openresty-testsuite:latest \
                -c 'luarocks make lua-resty-jwt-dev-0.rockspec && prove -r t'
         ;;
 esac

--- a/dist.ini
+++ b/dist.ini
@@ -1,10 +1,10 @@
 name = lua-resty-jwt
 abstract = JWT For The Great Openresty
-author = SkyLothar (skylothar)
+author = Christian Battaglia (cdbattags)
 is_original = yes
 license = apache2
 lib_dir = lib
 doc_dir = lib
-repo_link = https://github.com/SkyLothar/lua-resty-jwt
+repo_link = https://github.com/cdbattags/lua-resty-jwt
 main_module = lib/resty/jwt.lua
 requires = luajit, jkeys089/lua-resty-hmac >= 0.02

--- a/lib/resty/evp.lua
+++ b/lib/resty/evp.lua
@@ -3,7 +3,8 @@
 
 local ffi = require "ffi"
 local _C = ffi.C
-local _M = { _VERSION = "0.0.2" }
+local _M = { _VERSION = "0.2.0" }
+local ngx = ngx
 
 
 local CONST = {
@@ -134,12 +135,15 @@ end
 
 local ctx_new, ctx_free
 local openssl11, e = pcall(function ()
-    local ctx = _C.HMAC_CTX_new()
-    _C.HMAC_CTX_free(ctx)
+    local ctx = _C.EVP_MD_CTX_new()
+    _C.EVP_MD_CTX_free(ctx)
 end)
+
+ngx.log(ngx.DEBUG, "openssl11=", openssl11, " err=", e)
+
 if openssl11 then
     ctx_new = function ()
-        return _C.HMAC_CTX_new()
+        return _C.EVP_MD_CTX_new()
     end
     ctx_free = function (ctx)
         ffi.gc(ctx, _C.EVP_MD_CTX_free)

--- a/lib/resty/jwt-validators.lua
+++ b/lib/resty/jwt-validators.lua
@@ -1,4 +1,4 @@
-local _M = {_VERSION="0.1.5"}
+local _M = {_VERSION="0.2.0"}
 
 --[[
   This file defines "validators" to be used in validating a spec.  A "validator" is simply a function with

--- a/lib/resty/jwt.lua
+++ b/lib/resty/jwt.lua
@@ -5,7 +5,7 @@ local evp = require "resty.evp"
 local hmac = require "resty.hmac"
 local resty_random = require "resty.random"
 
-local _M = {_VERSION="0.1.12"}
+local _M = {_VERSION="0.2.0"}
 local mt = {__index=_M}
 
 local string_match= string.match

--- a/lib/resty/jwt.lua
+++ b/lib/resty/jwt.lua
@@ -5,7 +5,7 @@ local evp = require "resty.evp"
 local hmac = require "resty.hmac"
 local resty_random = require "resty.random"
 
-local _M = {_VERSION="0.1.11"}
+local _M = {_VERSION="0.1.12"}
 local mt = {__index=_M}
 
 local string_match= string.match

--- a/t/load-verify-jwe.t
+++ b/t/load-verify-jwe.t
@@ -39,7 +39,7 @@ __DATA__
 --- request
 GET /t
 --- response_body
-{"payload":{"foo":"bar"},"reason":"everything is awesome~ :p","header":{"alg":"dir","enc":"A256CBC-HS512"},"valid":true,"verified":true}
+{"reason":"everything is awesome~ :p","valid":true,"payload":{"foo":"bar"},"header":{"alg":"dir","enc":"A256CBC-HS512"},"verified":true}
 --- no_error_log
 [error]
 
@@ -66,7 +66,7 @@ GET /t
 --- request
 GET /t
 --- response_body
-{"payload":{"foo":"bar"},"reason":"everything is awesome~ :p","header":{"alg":"dir","enc":"A128CBC-HS256"},"valid":true,"verified":true}
+{"reason":"everything is awesome~ :p","valid":true,"payload":{"foo":"bar"},"header":{"alg":"dir","enc":"A128CBC-HS256"},"verified":true}
 --- no_error_log
 [error]
 


### PR DESCRIPTION
- update test suite to use https://github.com/cdbattags/openresty-testsuite/tree/v1.13.6.2
- fix OpenSSL 1.1 support with proper FFI function check