### PR TITLE
Allow to use secret in DER format

### DIFF
--- a/lib/resty/jwt.lua
+++ b/lib/resty/jwt.lua
@@ -777,6 +777,9 @@ function _M.verify_jwt_obj(self, secret, jwt_obj, ...)
         cert, err = evp.Cert:new(secret)
       elseif secret:find("PUBLIC KEY") then
         cert, err = evp.PublicKey:new(secret)
+      else
+        -- allow to use secret in DER format, digital, not base64 encoded
+        cert, err = evp.Cert:new(secret)
       end
       if not cert then
         jwt_obj[str_const.reason] = "Decode secret is not a valid cert/public key"


### PR DESCRIPTION
The secret must be digital, not base64 encoded.

The rationale:

In our use case, JWT doesn't have `x5c` or `x5u` header parameters, but `kid`.
We get valid keys from `jwks` uri of OpenId Connect server.

With current code I need to convert the x5c value returned by jwks uri into PEM format.
IMO it is waste of time, because I already have it in DER format.
