### PR TITLE
fix exp and nfb options validation

### DIFF
--- a/lib/resty/jwt.lua
+++ b/lib/resty/jwt.lua
@@ -380,8 +380,8 @@ _M.alg_whitelist = nil
 --- applied upon the verification of a jwt.
 function _M.get_default_validation_options(self, jwt_obj)
   return {
-    [str_const.require_exp_claim]=jwt_obj.exp ~= nil,
-    [str_const.require_nbf_claim]=jwt_obj.nbf ~= nil
+    [str_const.require_exp_claim]=jwt_obj[str_const.payload].exp ~= nil,
+    [str_const.require_nbf_claim]=jwt_obj[str_const.payload].nbf ~= nil
   }
 end
 


### PR DESCRIPTION
Currently those options validation are always false
because it's not checked in the payload part which
contains exp and nfb claims