### PR TITLE
Feature/jwe compression

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ lua-resty-jwt - [JWT](http://self-issued.info/docs/draft-jones-json-web-token-01
     * [set_alg_whitelist](#set_alg_whitelist)
     * [set_trusted_certs_file](#set_trusted_certs_file)
     * [sign JWE](#sign-jwe)
+    * [register_compression_alg](#register_compression_alg)
 * [Verification](#verification)
     * [JWT Validators](#jwt-validators)
     * [Legacy/Timeframe options](#legacy-timeframe-options)
@@ -199,6 +200,12 @@ sign a table_of_jwt to a jwt_token.
 The `alg` argument specifies which key management algorithm to use (`dir`, `RSA-OAEP`, `RSA-OAEP-256`, `ECDH-ES`).
 The `enc` argument specifies which content encryption algorithm to use (`A128CBC-HS256`, `A256CBC-HS512`, `A128GCM`, `A256GCM`).
 
+The optional `zip` header parameter (RFC 7516 §4.1.3) enables payload compression before
+encryption. The only standards-registered value is `DEF` (raw DEFLATE per RFC 1951),
+which is handled out-of-the-box when [lua-zlib](https://github.com/brimworks/lua-zlib)
+is installed (`luarocks install lua-zlib`). The same header is honored on
+`jwt:verify` / `jwt:load_jwt`.
+
 ### sample of table_of_jwt ###
 
 ```
@@ -206,6 +213,34 @@ The `enc` argument specifies which content encryption algorithm to use (`A128CBC
     "header": {"typ": "JWE", "alg": "dir", "enc":"A128CBC-HS256"},
     "payload": {"foo": "bar"}
 }
+```
+
+### sample with DEFLATE compression ###
+
+```
+{
+    "header": {"typ": "JWE", "alg": "dir", "enc":"A128CBC-HS256", "zip": "DEF"},
+    "payload": {"foo": "bar"}
+}
+```
+
+## register_compression_alg
+
+`syntax: jwt:register_compression_alg(name, { deflate = fn, inflate = fn })`
+
+Register or override the handler used for a given JWE `zip` header value. The
+default `DEF` handler is registered at load time using `lua-zlib`; call this if
+you want to swap in a different DEFLATE implementation (pure-Lua, FFI, etc.) or
+if `lua-zlib` is not available in your environment.
+
+`deflate` and `inflate` each take a byte string and must return either a byte
+string on success, or `nil, err` on failure.
+
+```lua
+jwt:register_compression_alg("DEF", {
+    deflate = function(data) return my_compress(data) end,
+    inflate = function(data) return my_decompress(data) end,
+})
 ```
 
 [Back to TOC](#table-of-contents)

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ lua-resty-jwt - [JWT](http://self-issued.info/docs/draft-jones-json-web-token-01
     * [set_alg_whitelist](#set_alg_whitelist)
     * [set_trusted_certs_file](#set_trusted_certs_file)
     * [sign JWE](#sign-jwe)
+    * [register_zlib_compression](#register_zlib_compression)
     * [register_compression_alg](#register_compression_alg)
 * [Verification](#verification)
     * [JWT Validators](#jwt-validators)
@@ -200,11 +201,29 @@ sign a table_of_jwt to a jwt_token.
 The `alg` argument specifies which key management algorithm to use (`dir`, `RSA-OAEP`, `RSA-OAEP-256`, `ECDH-ES`).
 The `enc` argument specifies which content encryption algorithm to use (`A128CBC-HS256`, `A256CBC-HS512`, `A128GCM`, `A256GCM`).
 
-The optional `zip` header parameter (RFC 7516 §4.1.3) enables payload compression before
-encryption. The only standards-registered value is `DEF` (raw DEFLATE per RFC 1951),
-which is handled out-of-the-box when [lua-zlib](https://github.com/brimworks/lua-zlib)
-is installed (`luarocks install lua-zlib`). The same header is honored on
-`jwt:verify` / `jwt:load_jwt`.
+The optional `zip` header parameter (RFC 7516 §4.1.3) enables payload compression
+before encryption. **Compression is disabled by default** because compress-then-encrypt
+leaks information about the plaintext through the resulting ciphertext length
+(CRIME / BREACH family of attacks), and a token that arrives with a `zip` header
+will be rejected with `unsupported zip: …` unless a handler has been registered.
+
+To opt in to the built-in `DEF` handler (raw DEFLATE per RFC 1951), install
+[lua-zlib](https://github.com/brimworks/lua-zlib) and hand the module to
+`jwt:register_zlib_compression` once during startup. Passing the module
+explicitly keeps `lua-zlib` an optional dependency of this library and makes
+the opt-in step unambiguous:
+
+```
+luarocks install lua-zlib
+```
+
+```lua
+local jwt = require "resty.jwt"
+jwt:register_zlib_compression(require "zlib")
+```
+
+Alternatively, register your own handler (pure-Lua, FFI, or a different alg
+name entirely) via `jwt:register_compression_alg` — see below.
 
 ### sample of table_of_jwt ###
 
@@ -224,14 +243,29 @@ is installed (`luarocks install lua-zlib`). The same header is honored on
 }
 ```
 
+## register_zlib_compression
+
+`syntax: jwt:register_zlib_compression(zlib_module)`
+
+Register the `DEF` (raw DEFLATE per RFC 1951) compression handler using a
+caller-supplied [lua-zlib](https://github.com/brimworks/lua-zlib)-compatible
+module. Passing the module explicitly keeps `lua-zlib` an optional dependency
+and makes JWE compression opt-in; see the security note under
+[sign-jwe](#sign-jwe).
+
+```lua
+jwt:register_zlib_compression(require "zlib")
+```
+
 ## register_compression_alg
 
 `syntax: jwt:register_compression_alg(name, { deflate = fn, inflate = fn })`
 
-Register or override the handler used for a given JWE `zip` header value. The
-default `DEF` handler is registered at load time using `lua-zlib`; call this if
-you want to swap in a different DEFLATE implementation (pure-Lua, FFI, etc.) or
-if `lua-zlib` is not available in your environment.
+Register or override the handler used for a given JWE `zip` header value. Use
+this to swap in an alternate DEFLATE implementation (pure-Lua, FFI, etc.) or to
+support a non-standard `zip` value. No `zip` handler is registered out of the
+box — see [register_zlib_compression](#register_zlib_compression) for the
+standard `DEF` case.
 
 `deflate` and `inflate` each take a byte string and must return either a byte
 string on success, or `nil, err` on failure.
@@ -242,6 +276,12 @@ jwt:register_compression_alg("DEF", {
     inflate = function(data) return my_decompress(data) end,
 })
 ```
+
+For a concrete reference implementation, see how
+[`register_zlib_compression`](#register_zlib_compression) wires `lua-zlib` into
+this API in `lib/resty/jwt.lua` — it builds the `{ deflate, inflate }` pair
+around the zlib streaming API (with `windowBits = -15` for raw DEFLATE per
+RFC 1951) and hands it straight to `register_compression_alg`.
 
 [Back to TOC](#table-of-contents)
 

--- a/ci
+++ b/ci
@@ -10,4 +10,4 @@ docker run \
   -w /lua-resty-jwt \
   --name lua-resty-jwt-tests \
   "$IMAGE" \
-  -c 'luarocks make lua-resty-jwt-dev-0.rockspec && prove -j4 -r t; rc=$?; rm -rf t/servroot_* 2>/dev/null; exit $rc'
+  -c '(dpkg -s zlib1g-dev >/dev/null 2>&1 || (apt-get update -qq && apt-get install -y --no-install-recommends zlib1g-dev)) && luarocks install lua-zlib 1.3-0 && luarocks make lua-resty-jwt-dev-0.rockspec && prove -j4 -r t; rc=$?; rm -rf t/servroot_* 2>/dev/null; exit $rc'

--- a/ci-coverage
+++ b/ci-coverage
@@ -11,7 +11,9 @@ docker run \
   --name lua-resty-jwt-coverage \
   "$IMAGE" \
   -c '
+    dpkg -s zlib1g-dev >/dev/null 2>&1 || (apt-get update -qq && apt-get install -y --no-install-recommends zlib1g-dev)
     luarocks install luacov
+    luarocks install lua-zlib 1.3-0
     luarocks make lua-resty-jwt-dev-0.rockspec
 
     rm -f luacov.stats.out luacov.report.out

--- a/lib/resty/jwt.lua
+++ b/lib/resty/jwt.lua
@@ -489,41 +489,12 @@ end
 
 -- Registry for JWE "zip" header parameter handlers (RFC 7516 §4.1.3).
 -- Each handler is a table { deflate = fn(bytes)->bytes,err  inflate = fn(bytes)->bytes,err }.
+-- Intentionally empty by default: compression-then-encryption is vulnerable to
+-- CRIME/BREACH-style side-channel attacks when an attacker can influence part of
+-- the plaintext, so callers must explicitly opt in — either via
+-- jwt:register_zlib_compression(require "zlib") (which binds "DEF" to lua-zlib)
+-- or by registering their own handler with jwt:register_compression_alg.
 local compression_algs = {}
-
--- Build the default "DEF" handler (raw DEFLATE per RFC 1951, windowBits = -15)
--- on first use, so that lua-zlib remains an optional dependency.
-local function build_default_def_handler()
-  local ok, zlib = pcall(require, "zlib")
-  if not ok then
-    local err_msg = "lua-zlib is not installed; install it (luarocks install lua-zlib) "
-                 .. "or register a custom 'DEF' handler via jwt:register_compression_alg"
-    return {
-      deflate = function() return nil, err_msg end,
-      inflate = function() return nil, err_msg end,
-    }
-  end
-  return {
-    deflate = function(data)
-      local stream = zlib.deflate(zlib.BEST_COMPRESSION, -15)
-      local ok2, compressed = pcall(stream, data, "finish")
-      if not ok2 then
-        return nil, tostring(compressed)
-      end
-      return compressed
-    end,
-    inflate = function(data)
-      local stream = zlib.inflate(-15)
-      local ok2, decompressed = pcall(stream, data, "finish")
-      if not ok2 then
-        return nil, tostring(decompressed)
-      end
-      return decompressed
-    end,
-  }
-end
-
-compression_algs[str_const.DEF] = build_default_def_handler()
 
 --@function parse_jwe
 --@param pre-shared key
@@ -1502,9 +1473,9 @@ function _M.set_payload_decoder(self, decoder)
 end
 
 
--- Register or override a handler for the JWE "zip" header parameter.
--- `handler` must be a table with function fields `deflate` and `inflate`,
--- each taking a byte string and returning (bytes) or (nil, err).
+--@function register_compression_alg : register a handler for the given JWE "zip" header value
+--@param name : the `zip` header value to bind (e.g. "DEF")
+--@param handler : a table { deflate = fn(bytes)->bytes,err  inflate = fn(bytes)->bytes,err }
 function _M.register_compression_alg(self, name, handler)
   if type(name) ~= "string" or name == "" then
     error({reason="compression alg name must be a non-empty string"})
@@ -1515,6 +1486,42 @@ function _M.register_compression_alg(self, name, handler)
     error({reason="compression handler must be a table with deflate and inflate functions"})
   end
   compression_algs[name] = handler
+end
+
+
+--@function register_zlib_compression : bind the JWE "DEF" zip alg to a caller-supplied lua-zlib module
+--@param zlib : a lua-zlib-compatible module (typically the result of `require "zlib"`).
+--              Passing it in keeps the dependency caller-owned and makes the call itself the opt-in.
+--              JWE compression is disabled by default because compress-then-encrypt leaks
+--              information about plaintext through ciphertext length (CRIME / BREACH family);
+--              only enable it when attacker-chosen plaintext cannot be mixed with secrets.
+--              Note: DEFLATE can expand modest inputs into very large outputs ("decompression
+--              bombs"); consumers that accept untrusted JWEs should bound the ciphertext size
+--              before calling verify/load to keep the inflate step's memory cost predictable.
+function _M.register_zlib_compression(self, zlib)
+  if type(zlib) ~= "table"
+      or type(zlib.deflate) ~= "function"
+      or type(zlib.inflate) ~= "function" then
+    error({reason="zlib module must expose deflate and inflate functions (pass `require \"zlib\"`)"})
+  end
+  _M.register_compression_alg(self, str_const.DEF, {
+    deflate = function(data)
+      local stream = zlib.deflate(zlib.BEST_COMPRESSION, -15)
+      local ok, compressed = pcall(stream, data, "finish")
+      if not ok then
+        return nil, tostring(compressed)
+      end
+      return compressed
+    end,
+    inflate = function(data)
+      local stream = zlib.inflate(-15)
+      local ok, decompressed = pcall(stream, data, "finish")
+      if not ok then
+        return nil, tostring(decompressed)
+      end
+      return decompressed
+    end,
+  })
 end
 
 

--- a/lib/resty/jwt.lua
+++ b/lib/resty/jwt.lua
@@ -111,6 +111,8 @@ local str_const = {
   PBES2_HS384_A192KW = "PBES2-HS384+A192KW",
   PBES2_HS512_A256KW = "PBES2-HS512+A256KW",
   DIR = "dir",
+  zip = "zip",
+  DEF = "DEF",
   reason = "reason",
   verified = "verified",
   number = "number",
@@ -485,6 +487,44 @@ local function get_payload_decoder(self)
     return self.payload_decoder or cjson_decode
 end
 
+-- Registry for JWE "zip" header parameter handlers (RFC 7516 §4.1.3).
+-- Each handler is a table { deflate = fn(bytes)->bytes,err  inflate = fn(bytes)->bytes,err }.
+local compression_algs = {}
+
+-- Build the default "DEF" handler (raw DEFLATE per RFC 1951, windowBits = -15)
+-- on first use, so that lua-zlib remains an optional dependency.
+local function build_default_def_handler()
+  local ok, zlib = pcall(require, "zlib")
+  if not ok then
+    local err_msg = "lua-zlib is not installed; install it (luarocks install lua-zlib) "
+                 .. "or register a custom 'DEF' handler via jwt:register_compression_alg"
+    return {
+      deflate = function() return nil, err_msg end,
+      inflate = function() return nil, err_msg end,
+    }
+  end
+  return {
+    deflate = function(data)
+      local stream = zlib.deflate(zlib.BEST_COMPRESSION, -15)
+      local ok2, compressed = pcall(stream, data, "finish")
+      if not ok2 then
+        return nil, tostring(compressed)
+      end
+      return compressed
+    end,
+    inflate = function(data)
+      local stream = zlib.inflate(-15)
+      local ok2, decompressed = pcall(stream, data, "finish")
+      if not ok2 then
+        return nil, tostring(decompressed)
+      end
+      return decompressed
+    end,
+  }
+end
+
+compression_algs[str_const.DEF] = build_default_def_handler()
+
 --@function parse_jwe
 --@param pre-shared key
 --@encoded-header
@@ -640,6 +680,17 @@ local function parse_jwe(self, preshared_key, encoded_header, encoded_encrypted_
     error({reason="failed to decrypt payload: " .. err})
 
   else
+    if header.zip then
+      local handler = compression_algs[header.zip]
+      if not handler then
+        error({reason="unsupported zip: " .. header.zip})
+      end
+      local inflated, zerr = handler.inflate(payload)
+      if zerr or not inflated then
+        error({reason="failed to decompress payload: " .. (zerr or "unknown error")})
+      end
+      payload = inflated
+    end
     basic_jwe.payload = get_payload_decoder(self)(payload)
     basic_jwe.internal.json_payload=payload
   end
@@ -812,6 +863,17 @@ local function sign_jwe(self, secret_key, jwt_obj)
   local key, encrypted_key, mac_key, enc_key, _
   local encoded_header = _M:jwt_encode(header)
   local payload_to_encrypt = get_payload_encoder(self)(jwt_obj.payload)
+  if header.zip then
+    local handler = compression_algs[header.zip]
+    if not handler then
+      error({reason="unsupported zip: " .. header.zip})
+    end
+    local compressed, zerr = handler.deflate(payload_to_encrypt)
+    if zerr or not compressed then
+      error({reason="failed to compress payload: " .. (zerr or "unknown error")})
+    end
+    payload_to_encrypt = compressed
+  end
   if alg ==  str_const.DIR then
     _, mac_key, enc_key = derive_keys(enc, secret_key)
     encrypted_key = ""
@@ -1437,6 +1499,22 @@ function _M.set_payload_decoder(self, decoder)
     error({reason="payload decoder must be function"})
   end
   self.payload_decoder= decoder
+end
+
+
+-- Register or override a handler for the JWE "zip" header parameter.
+-- `handler` must be a table with function fields `deflate` and `inflate`,
+-- each taking a byte string and returning (bytes) or (nil, err).
+function _M.register_compression_alg(self, name, handler)
+  if type(name) ~= "string" or name == "" then
+    error({reason="compression alg name must be a non-empty string"})
+  end
+  if type(handler) ~= "table"
+      or type(handler.deflate) ~= "function"
+      or type(handler.inflate) ~= "function" then
+    error({reason="compression handler must be a table with deflate and inflate functions"})
+  end
+  compression_algs[name] = handler
 end
 
 

--- a/lib/resty/jwt.lua
+++ b/lib/resty/jwt.lua
@@ -518,6 +518,11 @@ local function parse_jwe(self, preshared_key, encoded_header, encoded_encrypted_
     error({reason="invalid algorithm: " .. alg})
   end
 
+  -- Fail fast on unsupported compression before doing any expensive crypto work.
+  if header.zip and not compression_algs[header.zip] then
+    error({reason="unsupported zip: " .. header.zip})
+  end
+
   local key, enc_key, _
   if alg == str_const.DIR then
     if not preshared_key  then

--- a/t/load-verify-jwe.t
+++ b/t/load-verify-jwe.t
@@ -2152,3 +2152,274 @@ success: false
 has_reason: true
 --- no_error_log
 [error]
+
+
+=== TEST 56: Round-trip dir + A128CBC-HS256 with zip=DEF
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua '
+            local jwt = require "resty.jwt"
+            local cjson = require "cjson"
+            local shared_key = "12341234123412341234123412341234"
+            local table_of_jwt = {
+              header = {
+                  typ = "JWE",
+                  alg = "dir",
+                  enc = "A128CBC-HS256",
+                  zip = "DEF",
+              },
+              payload = { foo = "bar" }
+            }
+            local jwt_token = jwt:sign(shared_key, table_of_jwt)
+            local jwt_obj = jwt:verify(shared_key, jwt_token)
+            ngx.say(
+                "zip: ", jwt_obj.header.zip, "\\n",
+                "payload_match: ", cjson.encode(table_of_jwt.payload) == cjson.encode(jwt_obj.payload), "\\n",
+                "valid: ", jwt_obj.valid, "\\n",
+                "verified: ", jwt_obj.verified
+            )
+        ';
+    }
+--- request
+GET /t
+--- response_body
+zip: DEF
+payload_match: true
+valid: true
+verified: true
+--- no_error_log
+[error]
+
+
+=== TEST 57: Round-trip RSA-OAEP-256 + A256GCM with zip=DEF
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua '
+            local jwt = require "resty.jwt"
+            local cjson = require "cjson"
+            local function get_testcert(name)
+                local f = io.open("/lua-resty-jwt/testcerts/" .. name)
+                local contents = f:read("*all")
+                f:close()
+                return contents
+            end
+            local table_of_jwt = {
+              header = {
+                  alg = "RSA-OAEP-256",
+                  enc = "A256GCM",
+                  typ = "JWE",
+                  zip = "DEF",
+              },
+              payload = { foo = "bar" }
+            }
+            local jwt_token = jwt:sign(get_testcert("cert-pubkey.pem"), table_of_jwt)
+            local jwt_obj = jwt:verify(get_testcert("cert-key.pem"), jwt_token)
+            ngx.say(
+                "zip: ", jwt_obj.header.zip, "\\n",
+                "payload_match: ", cjson.encode(table_of_jwt.payload) == cjson.encode(jwt_obj.payload), "\\n",
+                "valid: ", jwt_obj.valid, "\\n",
+                "verified: ", jwt_obj.verified
+            )
+        ';
+    }
+--- request
+GET /t
+--- response_body
+zip: DEF
+payload_match: true
+valid: true
+verified: true
+--- no_error_log
+[error]
+
+
+=== TEST 58: Round-trip ECDH-ES + A128CBC-HS256 with zip=DEF
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua '
+            local jwt = require "resty.jwt"
+            local cjson = require "cjson"
+            local function get_testcert(name)
+                local f = io.open("/lua-resty-jwt/testcerts/" .. name)
+                local contents = f:read("*all")
+                f:close()
+                return contents
+            end
+            local table_of_jwt = {
+              header = {
+                  alg = "ECDH-ES",
+                  enc = "A128CBC-HS256",
+                  typ = "JWE",
+                  zip = "DEF",
+              },
+              payload = { foo = "bar" }
+            }
+            local jwt_token = jwt:sign(get_testcert("ec_cert_pubkey.pem"), table_of_jwt)
+            local jwt_obj = jwt:verify(get_testcert("ec_cert-key.pem"), jwt_token)
+            ngx.say(
+                "zip: ", jwt_obj.header.zip, "\\n",
+                "payload_match: ", cjson.encode(table_of_jwt.payload) == cjson.encode(jwt_obj.payload), "\\n",
+                "valid: ", jwt_obj.valid, "\\n",
+                "verified: ", jwt_obj.verified
+            )
+        ';
+    }
+--- request
+GET /t
+--- response_body
+zip: DEF
+payload_match: true
+valid: true
+verified: true
+--- no_error_log
+[error]
+
+
+=== TEST 59: zip=DEF meaningfully shrinks a compressible payload
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua '
+            local jwt = require "resty.jwt"
+            local shared_key = "12341234123412341234123412341234"
+            local big = string.rep("compressible-payload-chunk-", 200)
+            local plain = jwt:sign(shared_key, {
+              header = { typ = "JWE", alg = "dir", enc = "A128CBC-HS256" },
+              payload = { data = big }
+            })
+            local zipped = jwt:sign(shared_key, {
+              header = { typ = "JWE", alg = "dir", enc = "A128CBC-HS256", zip = "DEF" },
+              payload = { data = big }
+            })
+            ngx.say("shrunk: ", #zipped < #plain / 2)
+            local jwt_obj = jwt:verify(shared_key, zipped)
+            ngx.say(
+                "valid: ", jwt_obj.valid, "\\n",
+                "verified: ", jwt_obj.verified, "\\n",
+                "payload_ok: ", jwt_obj.payload.data == big
+            )
+        ';
+    }
+--- request
+GET /t
+--- response_body
+shrunk: true
+valid: true
+verified: true
+payload_ok: true
+--- no_error_log
+[error]
+
+
+=== TEST 60: Unsupported zip value rejected on sign
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua '
+            local jwt = require "resty.jwt"
+            local shared_key = "12341234123412341234123412341234"
+            local success, err = pcall(function ()
+                jwt:sign(shared_key, {
+                    header = { typ = "JWE", alg = "dir", enc = "A128CBC-HS256", zip = "FOO" },
+                    payload = { foo = "bar" }
+                })
+            end)
+            ngx.say("success: ", success)
+            if not success then
+                ngx.say("reason: ", err.reason)
+            end
+        ';
+    }
+--- request
+GET /t
+--- response_body
+success: false
+reason: unsupported zip: FOO
+--- no_error_log
+[error]
+
+
+=== TEST 61: Decrypt rejects token whose zip handler reports error
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua '
+            local jwt = require "resty.jwt"
+            local shared_key = "12341234123412341234123412341234"
+            -- Produce a well-formed token with zip=DISABLED using a working
+            -- stub, then swap the handler so that inflate always errors.
+            jwt:register_compression_alg("DISABLED", {
+                deflate = function(d) return d end,
+                inflate = function(d) return d end,
+            })
+            local token = jwt:sign(shared_key, {
+                header = { typ = "JWE", alg = "dir", enc = "A128CBC-HS256", zip = "DISABLED" },
+                payload = { foo = "bar" }
+            })
+            jwt:register_compression_alg("DISABLED", {
+                deflate = function() return nil, "broken" end,
+                inflate = function() return nil, "broken" end,
+            })
+            local jwt_obj = jwt:verify(shared_key, token)
+            ngx.say("verified: ", jwt_obj.verified)
+            ngx.say("reason: ", jwt_obj.reason)
+        ';
+    }
+--- request
+GET /t
+--- response_body
+verified: false
+reason: failed to decompress payload: broken
+--- no_error_log
+[error]
+
+
+=== TEST 62: Custom compression handler is invoked on sign and verify
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua '
+            local jwt = require "resty.jwt"
+            local cjson = require "cjson"
+            local shared_key = "12341234123412341234123412341234"
+            local deflate_calls, inflate_calls = 0, 0
+            local function xor_bytes(d)
+                local out = {}
+                for i = 1, #d do
+                    out[i] = string.char(bit.bxor(string.byte(d, i), 0x55))
+                end
+                return table.concat(out)
+            end
+            jwt:register_compression_alg("XOR", {
+                deflate = function(d)
+                    deflate_calls = deflate_calls + 1
+                    return xor_bytes(d)
+                end,
+                inflate = function(d)
+                    inflate_calls = inflate_calls + 1
+                    return xor_bytes(d)
+                end,
+            })
+            local token = jwt:sign(shared_key, {
+                header = { typ = "JWE", alg = "dir", enc = "A128CBC-HS256", zip = "XOR" },
+                payload = { foo = "bar" }
+            })
+            local jwt_obj = jwt:verify(shared_key, token)
+            ngx.say("deflate_calls: ", deflate_calls)
+            ngx.say("inflate_calls: ", inflate_calls)
+            ngx.say("payload: ", cjson.encode(jwt_obj.payload))
+            ngx.say("verified: ", jwt_obj.verified)
+        ';
+    }
+--- request
+GET /t
+--- response_body
+deflate_calls: 1
+inflate_calls: 1
+payload: {"foo":"bar"}
+verified: true
+--- no_error_log
+[error]

--- a/t/load-verify-jwe.t
+++ b/t/load-verify-jwe.t
@@ -2161,6 +2161,7 @@ has_reason: true
         content_by_lua '
             local jwt = require "resty.jwt"
             local cjson = require "cjson"
+            jwt:register_zlib_compression(require "zlib")
             local shared_key = "12341234123412341234123412341234"
             local table_of_jwt = {
               header = {
@@ -2199,6 +2200,7 @@ verified: true
         content_by_lua '
             local jwt = require "resty.jwt"
             local cjson = require "cjson"
+            jwt:register_zlib_compression(require "zlib")
             local function get_testcert(name)
                 local f = io.open("/lua-resty-jwt/testcerts/" .. name)
                 local contents = f:read("*all")
@@ -2242,6 +2244,7 @@ verified: true
         content_by_lua '
             local jwt = require "resty.jwt"
             local cjson = require "cjson"
+            jwt:register_zlib_compression(require "zlib")
             local function get_testcert(name)
                 local f = io.open("/lua-resty-jwt/testcerts/" .. name)
                 local contents = f:read("*all")
@@ -2284,6 +2287,7 @@ verified: true
     location /t {
         content_by_lua '
             local jwt = require "resty.jwt"
+            jwt:register_zlib_compression(require "zlib")
             local shared_key = "12341234123412341234123412341234"
             local big = string.rep("compressible-payload-chunk-", 200)
             local plain = jwt:sign(shared_key, {
@@ -2421,5 +2425,33 @@ deflate_calls: 1
 inflate_calls: 1
 payload: {"foo":"bar"}
 verified: true
+--- no_error_log
+[error]
+
+
+=== TEST 63: zip=DEF rejected on sign when compression not enabled
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua '
+            local jwt = require "resty.jwt"
+            local shared_key = "12341234123412341234123412341234"
+            local success, err = pcall(function ()
+                jwt:sign(shared_key, {
+                    header = { typ = "JWE", alg = "dir", enc = "A128CBC-HS256", zip = "DEF" },
+                    payload = { foo = "bar" }
+                })
+            end)
+            ngx.say("success: ", success)
+            if not success then
+                ngx.say("reason: ", err.reason)
+            end
+        ';
+    }
+--- request
+GET /t
+--- response_body
+success: false
+reason: unsupported zip: DEF
 --- no_error_log
 [error]


### PR DESCRIPTION
  ## Summary

  Closes #70.                                                                                                                                                                                                                                                                                                             
   
  Adds RFC 7516 §4.1.3 `zip` header parameter support for both sign                                                                                                                                                                                                                                                       
  (encrypt) and verify (decrypt), wired up to the registered `DEF`
  value (raw DEFLATE per RFC 1951). Compression is **opt-in** —                                                                                                                                                                                                                                                           
  compress-then-encrypt leaks plaintext information through ciphertext                                                                                                                                                                                                                                                    
  length (CRIME / BREACH), so the registry ships empty and callers                                                                                                                                                                                                                                                        
  enable the `DEF` alg by injecting their own `lua-zlib`:                                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
  `jwt:register_zlib_compression(require "zlib")`                                                                                                                                                                                                                                                                           
                                                         
  A generic `jwt:register_compression_alg(name, handler)` is also                                                                                                                                                                                                                                                           
  exposed so callers can bind alternate backends (pure-Lua DEFLATE,
  project-specific zip values, etc.) — register_zlib_compression                                                                                                                                                                                                                                                          
  is itself just a wrapper over it.                                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                          
  No new hard dependency is added to the rockspec; users who want DEF                                                                                                                                                                                                                                                     
  install lua-zlib themselves.                           
                                                                                                                                                                                                                                                            
  Notes for reviewers                                                                                                                                                                                                                                                                                                     
   
  Commits                                                                                                                                                                                                                                                                                                                 
                                                         
  1. feat: core support — registry, sign_jwe / parse_jwe hooks,
  str_const entries.
  2. test: round-trip for dir + RSA-OAEP-256 + ECDH-ES,                                                                                                                                                                                                                                                                   
  size-shrinkage sanity check, error paths, custom-handler dispatch.
  3. refactor: flip to opt-in via register_zlib_compression;                                                                                                                                                                                                                                                              
  README + TEST 63 added.                                
  4. fix: reject unsupported zip before any crypto — a JWE whose                                                                                                                                                                                                                                                          
  zip isn't registered is now rejected immediately after the alg                                                                                                                                                                                                                                                          
  check in parse_jwe, before any RSA-OAEP / ECDH-ES key unwrap or                                                                                                                                                                                                                                                         
  AEAD decrypt, so a malformed header can't force expensive crypto.                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                          
  Test coverage                                          
                                                                                                                                                                                                                                                                                                                          
  - Round-trip across every currently-supported JWE key-management alg                                                                                                                                                                                                                                                    
  family (dir, RSA-OAEP-256, ECDH-ES).
  - Size-shrinkage assertion on a compressible payload — catches silent                                                                                                                                                                                                                                                   
  regressions where deflate degrades to a pass-through.                                                                                                                                                                                                                                                                   
  - Unknown zip rejected on both sign and verify paths.
  - Custom-handler registration exercised end-to-end.                                                                                                                                                                                                                                                                     
  - Full suite: 892 tests green across 11 files.                                                                                                                                                                                                                                                                          
   
  Security notes                                                                                                                                                                                                                                                                                                          
                                                         
  - README has an opt-in security note covering CRIME / BREACH.                                                                                                                                                                                                                                                           
  - Decompression-bomb risk is documented on register_zlib_compression
  — consumers accepting untrusted JWEs should bound ciphertext size                                                                                                                                                                                                                                                       
  before verify. 